### PR TITLE
frontend-bug-23-allow_comm_protocol_to_be_chosen_twice

### DIFF
--- a/views/sniffing/comm_protocol_select.py
+++ b/views/sniffing/comm_protocol_select.py
@@ -27,7 +27,7 @@ class CommunicationProtocolSelect(QWidget):
         self.protocol_combo.addItems(["SPI", "UART", "I2C", "None"])
         self.protocol_combo.setItemData(0, 0, role=Qt.UserRole - 1)
         self.protocol_combo.setCurrentIndex(0)
-        self.protocol_combo.currentIndexChanged.connect(self.show_selected_settings)
+        self.protocol_combo.activated.connect(self.show_selected_settings)
 
         self.protocol_pages = QStackedWidget()
 
@@ -44,7 +44,7 @@ class CommunicationProtocolSelect(QWidget):
 
     def show_selected_settings(self, index):
         if index >= 0:
-            self.selected_protocol = self.protocol_combo.currentText()
+            self.selected_protocol = self.protocol_combo.itemText(index)
 
             if self.selected_protocol == "SPI":
                 self.show_spi_settings()


### PR DESCRIPTION
- The bug was caused by `currentIndexChanged` method, because when you select the communication protocol again the index doesn't change